### PR TITLE
Add Struts analysis support

### DIFF
--- a/jasmine/src/main/java/exa/org/edge/StrutsCreateEdge.java
+++ b/jasmine/src/main/java/exa/org/edge/StrutsCreateEdge.java
@@ -1,0 +1,69 @@
+package exa.org.edge;
+
+import soot.*;
+import soot.jimple.Jimple;
+import soot.jimple.JimpleBody;
+import soot.jimple.NullConstant;
+import soot.Local;
+import soot.util.Chain;
+
+import java.util.Arrays;
+
+/**
+ * Simplified edge creator for Struts applications. It builds a dummy main
+ * method which invokes typical Struts entry points.
+ */
+public class StrutsCreateEdge {
+    protected String dummyClassName = "synthetic.struts.dummyMainClass";
+    public SootMethod projectMainMethod;
+
+    /**
+     * Initialize the call graph by creating entry points.
+     */
+    public void initCallGraph() {
+        generateEntryPoints();
+    }
+
+    private void generateEntryPoints() {
+        SootClass sClass = new SootClass(dummyClassName, Modifier.PUBLIC);
+        sClass.setSuperclass(Scene.v().getSootClass("java.lang.Object"));
+        Scene.v().addClass(sClass);
+        sClass.setApplicationClass();
+        SootMethod mainMethod = new SootMethod("main",
+                Arrays.asList(ArrayType.v(RefType.v("java.lang.String"), 1)),
+                VoidType.v(), Modifier.PUBLIC | Modifier.STATIC);
+        sClass.addMethod(mainMethod);
+        JimpleBody jimpleBody = createMainBody(mainMethod);
+        mainMethod.setActiveBody(jimpleBody);
+        projectMainMethod = mainMethod;
+    }
+
+    private JimpleBody createMainBody(SootMethod method) {
+        JimpleBody body = Jimple.v().newBody(method);
+        Chain<Local> locals = body.getLocals();
+        Local args = Jimple.v().newLocal("args", ArrayType.v(RefType.v("java.lang.String"), 1));
+        locals.add(args);
+        body.getUnits().add(Jimple.v().newIdentityStmt(args, Jimple.v().newParameterRef(args.getType(), 0)));
+
+        // Struts filter
+        SootClass filterClass = Scene.v().getSootClass("org.apache.struts2.dispatcher.ng.filter.StrutsPrepareAndExecuteFilter");
+        Local filter = Jimple.v().newLocal("filter", filterClass.getType());
+        locals.add(filter);
+        body.getUnits().add(Jimple.v().newAssignStmt(filter, Jimple.v().newNewExpr(filterClass.getType())));
+        body.getUnits().add(Jimple.v().newInvokeStmt(Jimple.v().newSpecialInvokeExpr(filter, filterClass.getMethod("void <init>()").makeRef())));
+        SootMethod doFilter = filterClass.getMethod("void doFilter(javax.servlet.ServletRequest,javax.servlet.ServletResponse,javax.servlet.FilterChain)");
+        body.getUnits().add(Jimple.v().newInvokeStmt(Jimple.v().newVirtualInvokeExpr(filter, doFilter.makeRef(), Arrays.asList(NullConstant.v(), NullConstant.v(), NullConstant.v()))));
+
+        // ParametersInterceptor
+        SootClass interceptorClass = Scene.v().getSootClass("com.opensymphony.xwork2.interceptor.ParametersInterceptor");
+        Local interceptor = Jimple.v().newLocal("interceptor", interceptorClass.getType());
+        locals.add(interceptor);
+        body.getUnits().add(Jimple.v().newAssignStmt(interceptor, Jimple.v().newNewExpr(interceptorClass.getType())));
+        body.getUnits().add(Jimple.v().newInvokeStmt(Jimple.v().newSpecialInvokeExpr(interceptor, interceptorClass.getMethod("void <init>()").makeRef())));
+        SootMethod doIntercept = interceptorClass.getMethod("java.lang.String doIntercept(com.opensymphony.xwork2.ActionInvocation)");
+        body.getUnits().add(Jimple.v().newInvokeStmt(Jimple.v().newVirtualInvokeExpr(interceptor, doIntercept.makeRef(), Arrays.asList(NullConstant.v()))));
+
+        body.getUnits().add(Jimple.v().newReturnVoidStmt());
+        return body;
+    }
+}

--- a/jasmine/src/main/java/exa/org/taint/StrutsAnalysis.java
+++ b/jasmine/src/main/java/exa/org/taint/StrutsAnalysis.java
@@ -1,0 +1,47 @@
+package exa.org.taint;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+
+import com.google.gson.Gson;
+import org.apache.commons.io.FileUtils;
+import soot.jimple.infoflow.taintWrappers.EasyTaintWrapper;
+
+/**
+ * Analysis entry point for Struts applications using the jasmine framework.
+ */
+public class StrutsAnalysis {
+    public static String SOURCE_FILE_NAME;
+    public static String MAIN_CLASS;
+    public static String EDGE_CONFIG_PROPERTIES;
+    public static String benchmark = "struts";
+    public static String analysisAlgorithm = "jasmine";
+
+    private void loadConstant() throws IOException {
+        String configFile = "src/main/resources/config.json";
+        String configFileInfo = FileUtils.readFileToString(new File(configFile), "UTF-8");
+        Gson gson = new Gson();
+        HashMap<String, String> map = gson.fromJson(configFileInfo, HashMap.class);
+        SOURCE_FILE_NAME = map.get("source");
+        MAIN_CLASS = map.get("main_class");
+        EDGE_CONFIG_PROPERTIES = map.get("edge_config");
+    }
+
+    public void analysis() throws IOException {
+        // Load configuration
+        loadConstant();
+        StrutsSetupApplication application = new StrutsSetupApplication();
+
+        // Create taint wrapper
+        File taintWrapperFile = new File(System.getProperty("user.dir") + File.separator + "EasyTaintWrapperSource.txt");
+        application.setTaintWrapper(new EasyTaintWrapper(taintWrapperFile));
+
+        // Run the analysis
+        application.runInfoflow(System.getProperty("user.dir") + File.separator + "SourcesAndSinks-" + benchmark + ".txt");
+    }
+
+    public static void main(String[] args) throws IOException {
+        new StrutsAnalysis().analysis();
+    }
+}

--- a/jasmine/src/main/java/exa/org/taint/StrutsSetupApplication.java
+++ b/jasmine/src/main/java/exa/org/taint/StrutsSetupApplication.java
@@ -1,0 +1,170 @@
+package exa.org.taint;
+
+import exa.org.edge.StrutsCreateEdge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import soot.*;
+import soot.Main;
+import soot.jimple.infoflow.android.InfoflowAndroidConfiguration;
+import soot.jimple.infoflow.android.data.parsers.PermissionMethodParser;
+import soot.jimple.infoflow.android.iccta.IccInstrumenter;
+import soot.jimple.infoflow.android.source.AccessPathBasedSourceSinkManager;
+import soot.jimple.infoflow.solver.memory.DefaultMemoryManagerFactory;
+import soot.jimple.infoflow.sourcesSinks.definitions.ISourceSinkDefinitionProvider;
+import soot.jimple.infoflow.taintWrappers.ITaintPropagationWrapper;
+import soot.jimple.infoflow.taintWrappers.ITaintWrapperDataFlowAnalysis;
+import soot.options.Options;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Setup class for running Struts taint analysis.
+ * This is largely based on {@link SpringSetupApplication} but uses
+ * {@link StrutsCreateEdge} to build the entry points.
+ */
+public class StrutsSetupApplication implements ITaintWrapperDataFlowAnalysis {
+    private final Logger logger = LoggerFactory.getLogger(StrutsSetupApplication.class);
+    private ITaintPropagationWrapper taintWrapper;
+    private InfoflowAndroidConfiguration config;
+
+    protected IccInstrumenter iccInstrumenter = null;
+
+    @Override
+    public void setTaintWrapper(ITaintPropagationWrapper taintWrapper) {
+        this.taintWrapper = taintWrapper;
+    }
+
+    @Override
+    public ITaintPropagationWrapper getTaintWrapper() {
+        return taintWrapper;
+    }
+
+    public void runInfoflow(String sourceSinkFile) {
+        try {
+            ISourceSinkDefinitionProvider parser = PermissionMethodParser.fromFile(new File(sourceSinkFile));
+            config = new InfoflowAndroidConfiguration();
+
+            IMyInfoFlow infoflow = createInfoflow();
+            ResultAggreator resultAggregator = new ResultAggreator();
+            infoflow.addResultsAvailableHandler(resultAggregator);
+
+            initializeSoot();
+            createMainMethod();
+
+            AccessPathBasedSourceSinkManager sourceSinkManager = new AccessPathBasedSourceSinkManager(
+                    parser.getSources(), parser.getSinks(), Collections.emptySet(), config, null);
+            infoflow.runAnalysis(sourceSinkManager, null);
+
+        } catch (IOException e) {
+            logger.error("read file error{}", (Object) e.getStackTrace());
+        }
+    }
+
+    private void createMainMethod() {
+        if (StrutsAnalysis.analysisAlgorithm.equals("jasmine")) {
+            StrutsCreateEdge edge = new StrutsCreateEdge();
+            edge.initCallGraph();
+            Scene.v().setMainClass(edge.projectMainMethod.getDeclaringClass());
+        } else {
+            ArrayList<SootMethod> entryPoints = EntryPointConfig.getEntryPoints(StrutsAnalysis.benchmark);
+            Scene.v().setEntryPoints(entryPoints);
+        }
+    }
+
+    private IMyInfoFlow createInfoflow() {
+        IMyInfoFlow info = new MyInfoFlow();
+        info.setConfig(config);
+        info.setTaintWrapper(taintWrapper);
+        info.setMemoryManagerFactory(new DefaultMemoryManagerFactory());
+        return info;
+    }
+
+    private void initializeSoot() {
+        logger.info("Initializing Soot...");
+
+        G.reset();
+        List<String> dir = BenchmarksConfig.getSourceProcessDir(StrutsAnalysis.benchmark);
+
+        if (StrutsAnalysis.analysisAlgorithm.equals("spark") || StrutsAnalysis.analysisAlgorithm.equals("jasmine")) {
+            Options.v().setPhaseOption("cg.spark", "on");
+            Options.v().setPhaseOption("cg.spark", "verbose:true");
+            Options.v().setPhaseOption("cg.spark", "enabled:true");
+            Options.v().setPhaseOption("cg.spark", "propagator:worklist");
+            Options.v().setPhaseOption("cg.spark", "simple-edges-bidirectional:false");
+            Options.v().setPhaseOption("cg.spark", "on-fly-cg:true");
+            Options.v().setPhaseOption("cg.spark", "double-set-old:hybrid");
+            Options.v().setPhaseOption("cg.spark", "double-set-new:hybrid");
+            Options.v().setPhaseOption("cg.spark", "set-impl:double");
+            Options.v().setPhaseOption("cg.spark", "apponly:true");
+            Options.v().setPhaseOption("cg.spark", "simple-edges-bidirectional:false");
+            Options.v().set_verbose(true);
+        } else {
+            Options.v().setPhaseOption("cg.cha", "on");
+            Options.v().setPhaseOption("cg.cha", "enabled:true");
+            Options.v().setPhaseOption("cg.cha", "verbose:true");
+            Options.v().setPhaseOption("cg.cha", "apponly:true");
+            Options.v().set_verbose(true);
+        }
+
+        Options.v().set_no_bodies_for_excluded(true);
+        Options.v().set_allow_phantom_refs(true);
+        Options.v().set_output_format(Options.output_format_none);
+        Options.v().set_whole_program(true);
+        Options.v().set_process_dir(dir);
+        Options.v().set_src_prec(Options.src_prec_apk_class_jimple);
+        Options.v().set_keep_offset(false);
+        Options.v().set_keep_line_number(true);
+        Options.v().set_throw_analysis(Options.throw_analysis_dalvik);
+        Options.v().set_ignore_resolution_errors(true);
+        Options.v().setPhaseOption("jb", "use-original-names:true");
+        Options.v().set_soot_classpath(getSootClassPath());
+        Main.v().autoSetOptions();
+        configureCallgraph();
+
+        Scene.v().loadNecessaryClasses();
+        PackManager.v().getPack("wjpp").apply();
+    }
+
+    private String getClasspath(String workDir) {
+        String sootCp = Scene.v().getSootClassPath();
+        String sootCps = "";
+        try (Stream<Path> paths = Files.walk(Paths.get(workDir))) {
+            sootCps = paths.filter(path -> path.toString().endsWith("jar"))
+                    .map(Path::toString)
+                    .collect(Collectors.joining(File.pathSeparator));
+        } catch (IOException e) {
+        }
+        sootCp += File.pathSeparator + sootCps;
+        return sootCp;
+    }
+
+    private static String getSootClassPath() {
+        String javaHome = System.getProperty("java.home");
+        if (javaHome == null || javaHome.equals(""))
+            throw new RuntimeException("Could not get property java.home!");
+        String sootCp = "../struts/rt.jar";
+
+        String dependencyDirectory = BenchmarksConfig.getDependencyDir(StrutsAnalysis.benchmark);
+
+        File file = new File(dependencyDirectory);
+        File[] fs = file.listFiles();
+        if (fs != null) {
+            for (File f : fs) {
+                if (!f.isDirectory())
+                    sootCp += File.pathSeparator + dependencyDirectory + File.separator + f.getName();
+            }
+        }
+
+        return sootCp;
+    }
+
+    private void configureCallgraph() {
+    }
+}


### PR DESCRIPTION
## Summary
- implement `StrutsAnalysis` as entry point for analysing Struts projects
- add `StrutsSetupApplication` mirroring Spring setup but using Struts entry points
- create `StrutsCreateEdge` to generate a dummy main invoking Struts filter and interceptor

## Testing
- `mvn -q -pl jasmine -am -DskipTests package` *(failed: exception during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68516e0772f4833088939a14f390309b